### PR TITLE
Fix typo.

### DIFF
--- a/src/game/world2/level3.lean
+++ b/src/game/world2/level3.lean
@@ -12,7 +12,7 @@ namespace mynat -- hide
 
   * `add_zero (a : mynat) : a + 0 = a`
   * `add_succ (a b : mynat) : a + succ(b) = succ(a + b)`
-  * `zero_add` (a : mynat) : 0 + a = a`
+  * `zero_add (a : mynat) : 0 + a = a`
   * `add_assoc (a b c : mynat) : (a + b) + c = a + (b + c)`
 
 Oh no! On the way to `add_comm`, a wild `succ_add` appears. `succ_add`


### PR DESCRIPTION
<img width="474" alt="Screen Shot 2019-10-26 at 5 01 15 PM" src="https://user-images.githubusercontent.com/194342/67614999-4ad3b900-f812-11e9-8b74-509c559da052.png">

Fix the broken `zero_add` line above.