### PR TITLE
Fixed some typos in World 3.

### DIFF
--- a/src/game/world3/level1.lean
+++ b/src/game/world3/level1.lean
@@ -17,7 +17,7 @@ with `a * 0` defined to be `0` and, if we know `a * b`, then `a` times
 the number after `b` is defined to be `a * b + b`. 
 
 You can keep all the theorems you proved about addition, but 
-for multiplication, those two results above are you've got right now.
+for multiplication, those two results above are all you've got right now.
 Like addition, we need to go for the proofs that multiplication
 is commutative and associative, but as well as that we will
 need to prove facts about the relationship between multiplication

--- a/src/game/world3/level1.lean
+++ b/src/game/world3/level1.lean
@@ -10,11 +10,11 @@ natural numbers. It is defined by recursion, just like addition.
 Here are the two new axioms:
 
   * `mul_zero : ∀ a : mynat, a * 0 = 0`
-  * `mul_succ : ∀ a b : mynat, a * succ(b) = a * b + b`
+  * `mul_succ : ∀ a b : mynat, a * succ(b) = a * b + a`
 
 In words, we define multiplication by "induction on the second variable",
 with `a * 0` defined to be `0` and, if we know `a * b`, then `a` times
-the number after `b` is defined to be `a * b + b`. 
+the number after `b` is defined to be `a * b + a`. 
 
 You can keep all the theorems you proved about addition, but 
 for multiplication, those two results above are all you've got right now.

--- a/src/game/world3/level2.lean
+++ b/src/game/world3/level2.lean
@@ -12,7 +12,7 @@ Currently our tools for multiplication are the
 following: 
 
 * `mul_zero : ∀ m, m * 0 = 0`
-* `zero_mul : ∀ m, 0 * m = m`
+* `zero_mul : ∀ m, 0 * m = 0`
 * `mul_succ : ∀ a b, a * succ b = a * b + b`
 
 We also have

--- a/src/game/world3/level2.lean
+++ b/src/game/world3/level2.lean
@@ -13,7 +13,7 @@ following:
 
 * `mul_zero : ∀ m, m * 0 = 0`
 * `zero_mul : ∀ m, 0 * m = 0`
-* `mul_succ : ∀ a b, a * succ b = a * b + b`
+* `mul_succ : ∀ a b, a * succ b = a * b + a`
 
 We also have
 

--- a/src/game/world3/level3.lean
+++ b/src/game/world3/level3.lean
@@ -14,7 +14,7 @@ following:
 * `mul_zero : ∀ m, m * 0 = 0`
 * `zero_mul : ∀ m, 0 * m = 0`
 * `mul_succ : ∀ a b, a * succ b = a * b + a`
-* `mul_one ; ∀ m, m * 1 = 1`
+* `mul_one ; ∀ m, m * 1 = m`
 
 We have also these other facts about 1 (the
 first is just the definition, the second was

--- a/src/game/world3/level3.lean
+++ b/src/game/world3/level3.lean
@@ -12,7 +12,7 @@ Currently our tools for multiplication are the
 following: 
 
 * `mul_zero : ∀ m, m * 0 = 0`
-* `zero_mul : ∀ m, 0 * m = m`
+* `zero_mul : ∀ m, 0 * m = 0`
 * `mul_succ : ∀ a b, a * succ b = a * b + b`
 * `mul_one ; ∀ m, m * 1 = 1`
 

--- a/src/game/world3/level3.lean
+++ b/src/game/world3/level3.lean
@@ -13,7 +13,7 @@ following:
 
 * `mul_zero : ∀ m, m * 0 = 0`
 * `zero_mul : ∀ m, 0 * m = 0`
-* `mul_succ : ∀ a b, a * succ b = a * b + b`
+* `mul_succ : ∀ a b, a * succ b = a * b + a`
 * `mul_one ; ∀ m, m * 1 = 1`
 
 We have also these other facts about 1 (the

--- a/src/game/world3/level4.lean
+++ b/src/game/world3/level4.lean
@@ -10,7 +10,7 @@ Currently our tools for multiplication include the
 following: 
 
 * `mul_zero : ∀ m, m * 0 = 0`
-* `zero_mul : ∀ m, 0 * m = m`
+* `zero_mul : ∀ m, 0 * m = 0`
 * `mul_succ : ∀ a b, a * succ b = a * b + b`
 
 but for addition we have `add_comm` and `add_assoc`

--- a/src/game/world3/level4.lean
+++ b/src/game/world3/level4.lean
@@ -11,7 +11,7 @@ following:
 
 * `mul_zero : ∀ m, m * 0 = 0`
 * `zero_mul : ∀ m, 0 * m = 0`
-* `mul_succ : ∀ a b, a * succ b = a * b + b`
+* `mul_succ : ∀ a b, a * succ b = a * b + a`
 
 but for addition we have `add_comm` and `add_assoc`
 and are in much better shape.

--- a/src/game/world3/level5.lean
+++ b/src/game/world3/level5.lean
@@ -13,7 +13,7 @@ following:
 
 * `mul_zero : ∀ m, m * 0 = 0`
 * `zero_mul : ∀ m, 0 * m = 0`
-* `mul_succ : ∀ a b, a * succ b = a * b + b`
+* `mul_succ : ∀ a b, a * succ b = a * b + a`
 * `mul_add : ∀ t a b , t * (a + b) = t * a + t * b`
 
 These things above are the tools we need to prove that multiplication is associative.

--- a/src/game/world3/level5.lean
+++ b/src/game/world3/level5.lean
@@ -12,7 +12,7 @@ Currently our tools for multiplication include the
 following: 
 
 * `mul_zero : ∀ m, m * 0 = 0`
-* `zero_mul : ∀ m, 0 * m = m`
+* `zero_mul : ∀ m, 0 * m = 0`
 * `mul_succ : ∀ a b, a * succ b = a * b + b`
 * `mul_add : ∀ t a b , t * (a + b) = t * a + t * b`
 

--- a/src/game/world3/level6.lean
+++ b/src/game/world3/level6.lean
@@ -17,7 +17,7 @@ Currently our tools for multiplication include the
 following: 
 
 * `mul_zero : ∀ a, a * 0 = 0`
-* `mul_succ : ∀ a b, a * succ b = a * b + b`
+* `mul_succ : ∀ a b, a * succ b = a * b + a`
 * `mul_add : ∀ a b c , a * (b + c) = a * b + a * c`
 
 and remember also that we have tools like


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1511180/67809044-df971a80-fa8f-11e9-8061-ab85942f679a.png)

Should be 

- zero_mul : ∀ m, 0 * m = 0
- mul_succ : ∀ a b, a * succ b = a * b + a
