### PR TITLE
Two small fixes

### DIFF
--- a/src/game/world7/level10.lean
+++ b/src/game/world7/level10.lean
@@ -6,7 +6,7 @@ local attribute [instance, priority 10] classical.prop_decidable -- hide
 
 ## Level 10: `exfalso` and proof by contradiction. 
 
-It's certainly true that $(P\land(\lnot P)\implies Q$ for any propositions $P$
+It's certainly true that $P\land(\lnot P)\implies Q$ for any propositions $P$
 and $Q$, because the left hand side of the implication is false. But how do
 we prove that `false` implies any proposition $Q$? A cheap way of doing it in
 Lean is using the `exfalso` tactic, which changes any goal at all to `false`. 

--- a/src/game/world8/level1.lean
+++ b/src/game/world8/level1.lean
@@ -3,7 +3,7 @@ import mynat.add -- hide
 import game.world2.level6 -- hide
 namespace mynat -- hide
 
-/- Axiom : succ_inj (a b : mynat) :
+/- Axiom : succ_inj {a b : mynat} :
   succ(a) = succ(b) → a = b
 -/
 
@@ -17,7 +17,7 @@ Peano's original collection of axioms for the natural numbers contained two furt
 assumptions, which have not yet been mentioned in the game:
 
 ```
-succ_inj (a b : mynat) :
+succ_inj {a b : mynat} :
   succ(a) = succ(b) → a = b
 
 zero_ne_succ (a : mynat) :


### PR DESCRIPTION
* Missing parenthesis in one of the non-computer-checked formulas. (As mentioned in #43.)

* `succ_inj` actually takes `a` and `b` as implicit arguments. I guess the entry in the "Theorem statements" in the in-game side bar (where I noticed the error) is generated from the "Axiom" declaration in the code (which I changed).

Aside: I imagine it would be great if the stated types of axioms were checked against the actual types in the corresponding definitions (in `src/mynat/definition.lean` in this case). See also #39. And note that even in the actual type of e.g. `add_zero` (as seen in error messages), the name of the variable differs from the type in the documentation side bar: `m` vs. `a`.

PS: Wrote my first Lean code today, thanks for the game!