### PR TITLE
Fix note about using have in world 10 level 7

### DIFF
--- a/src/game/world10/level7.lean
+++ b/src/game/world10/level7.lean
@@ -6,7 +6,7 @@ namespace mynat -- hide
 ## Level 7: `le_zero`
 
 We proved `add_right_eq_zero` back in advanced addition world.
-Note that you can do things like `have h2 := add_right_eq_zero _ _ h1`
+Note that you can do things like `have h2 := add_right_eq_zero h1`
 if `h1 : a + c = 0`.
 -/
 


### PR DESCRIPTION
Furthermore this note should probably be introduced in level 6, where you probably also need this.