### PR TITLE
Fix typo in world7/level5.lean.

### DIFF
--- a/src/game/world7/level5.lean
+++ b/src/game/world7/level5.lean
@@ -4,7 +4,7 @@
 
 ## Level 5: `iff_trans` easter eggs.
 
-Let's try ``iff_trans` again. Try proving it in other ways.
+Let's try `iff_trans` again. Try proving it in other ways.
 
 ### A trick.
 


### PR DESCRIPTION
That backtick was duplicated and was causing a lone backtick to show up on the website itself.