### PR TITLE
Add `not_iff_imp_false` to Advanced Proposition/Level 9

### DIFF
--- a/src/game/world7/level9.lean
+++ b/src/game/world7/level9.lean
@@ -1,6 +1,9 @@
 import game.world7.level8 -- hide
 import tactic.tauto -- useful high-powered tactic
 local attribute [instance, priority 10] classical.prop_decidable -- we are mathematicians
+
+lemma not_iff_imp_false (P : Prop) : ¬ P ↔ P → false := iff.rfl -- hide
+
 /- 
 # Advanced proposition world.
 


### PR DESCRIPTION
See Zulip conversation 

https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/Natural.20number.20game.2C.20excluded.20middle/near/196265332

The code snippet in the level checks with no errors, but this is only because of `repeat` suppressing the `unknown identifier` error from the `rw`. Which means if someone tries to write just `rw not_iff_imp_false` they get an error, even though it "works" in the `repeat`.

(Would it be better to import world6/level8 instead?)