### PR TITLE
The lines "-- World name : ..." removed

### DIFF
--- a/src/game/world1/level1.lean
+++ b/src/game/world1/level1.lean
@@ -3,7 +3,6 @@ import mynat.add -- imports definition of addition on the natural numbers.
 import mynat.mul -- imports definition of multiplication on the natural numbers.
 namespace mynat -- hide
 
--- World name : Tutorial world
 
 /- 
 # Tutorial World

--- a/src/game/world10/level1.lean
+++ b/src/game/world10/level1.lean
@@ -23,7 +23,6 @@ form, `use 0` will turn the goal into `⊢ P(0)`, `use x + y` (assuming
 the goal into `P(x + y)` and so on.
 -/
 
--- World name : Inequality world
 /- 
 
 # Inequality world. 

--- a/src/game/world2/level1.lean
+++ b/src/game/world2/level1.lean
@@ -2,7 +2,6 @@ import mynat.definition -- Imports the natural numbers.
 import mynat.add -- imports addition.
 namespace mynat -- hide
 
--- World name : Addition world
 
 /- Axiom : add_zero (a : mynat) :
 a + 0 = a

--- a/src/game/world3/level1.lean
+++ b/src/game/world3/level1.lean
@@ -1,7 +1,6 @@
 import game.world2.level6 -- hide
 import mynat.mul -- import the definition of multiplication on mynat
 
--- World name : Multiplication world
 
 /- Axiom : mul_zero (a : mynat) :
 a * 0 = 0

--- a/src/game/world4/level1.lean
+++ b/src/game/world4/level1.lean
@@ -2,7 +2,6 @@ import game.world3.level9 -- hide
 import mynat.pow -- new import
 namespace mynat -- hide
 
--- World name : Power world
 
 /- Axiom : pow_zero (a : mynat) :
 a ^ 0 = 1

--- a/src/game/world5/level1.lean
+++ b/src/game/world5/level1.lean
@@ -1,4 +1,3 @@
--- World name : Function world
 /- 
 
 # Function world. 

--- a/src/game/world6/level1.lean
+++ b/src/game/world6/level1.lean
@@ -1,4 +1,3 @@
--- World name : Proposition world
 /- 
 
 # Proposition world. 

--- a/src/game/world7/level1.lean
+++ b/src/game/world7/level1.lean
@@ -1,4 +1,3 @@
--- World name : Advanced Proposition world
 /- 
 
 # Advanced proposition world. 


### PR DESCRIPTION
In earlier versions, the name of the world was specified in the first level of each world. Now that the world names are specified in `game_config.toml`, those lines are redundant. 