### PR TITLE
Improve wording in multiplication distributivity lemmas

### DIFF
--- a/src/game/world3/level4.lean
+++ b/src/game/world3/level4.lean
@@ -23,7 +23,7 @@ an alternative name for the proof of this lemma.
 -/
 
 /- Lemma
-Multiplication is distributive over addition.
+Multiplication is left distributive over addition.
 In other words, for all natural numbers $a$, $b$ and $t$, we have
 $$ t(a + b) = ta + tb. $$
 -/

--- a/src/game/world3/level7.lean
+++ b/src/game/world3/level7.lean
@@ -19,7 +19,7 @@ just try `simp`.
 -/
 
 /- Lemma
-Addition is distributive over multiplication.
+Multiplication is right distributive over addition.
 In other words, for all natural numbers $a$, $b$ and $t$, we have
 $$ (a + b) \times t = at + bt. $$
 -/


### PR DESCRIPTION
"Addition is distributive over multiplication." means that `a + (b * c) = (a + b) * (a + c)`, which is not true in general. Usually I hear "left distributive" to mean multiplication on the left, and "right distributive" to mean multiplication on the right, so that's what I have changed it to here.